### PR TITLE
Bump base image to ubi9

### DIFF
--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1154 AS base
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1736404155 AS base
 ARG TARGETARCH
 USER root
 RUN microdnf install -y tar gzip make which git gcc go-toolset


### PR DESCRIPTION
- Bumps base image to ubi9

Validated in CRC
<img width="664" alt="Screenshot 2025-01-30 at 2 15 20 PM" src="https://github.com/user-attachments/assets/4c1d05f3-72e3-4067-9c3c-d987c4bc2f0e" />

Manifest https://quay.io/repository/tcreller/spicedb/manifest/sha256:a925abe1870832b3cc81b46159e11ab0ae31fc8caa98b796ff7facfdc66f3b83