### PR TITLE
Fix image build issues

### DIFF
--- a/.tekton/spicedb-pull-request.yaml
+++ b/.tekton/spicedb-pull-request.yaml
@@ -267,7 +267,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:80a4562d5f86eb6812f00d4e30e94c1ad27ec937735dc29f5a63e9335676b3dc
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1b6c20ab3dbfb0972803d3ebcb2fa72642e59400c77bd66dfd82028bdd09e120
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/spicedb-push.yaml
+++ b/.tekton/spicedb-push.yaml
@@ -264,7 +264,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:80a4562d5f86eb6812f00d4e30e94c1ad27ec937735dc29f5a63e9335676b3dc
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1b6c20ab3dbfb0972803d3ebcb2fa72642e59400c77bd66dfd82028bdd09e120
         - name: kind
           value: task
         resolver: bundles

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -19,7 +19,7 @@ FROM base AS health-probe-builder
 WORKDIR /go/src/app
 RUN git clone https://github.com/authzed/grpc-health-probe.git
 WORKDIR /go/src/app/grpc-health-probe
-RUN git checkout 199609b3f49ede781d86d560e1fc2735115be834
+RUN git checkout c6748c5fa9df494f5bf671052a8351af37af0cb3
 RUN GOEXPERIMENT=strictfipsruntime,boringcrypto CGO_ENABLED=1 GOBIN=/go/bin go install -a -tags netgo -ldflags=-w
 
 # Final stage

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -19,7 +19,7 @@ FROM base AS health-probe-builder
 WORKDIR /go/src/app
 RUN git clone https://github.com/authzed/grpc-health-probe.git
 WORKDIR /go/src/app/grpc-health-probe
-RUN git checkout 9d30dbbc7936d5fff08d4cf6abc6444777977b39
+RUN git checkout 199609b3f49ede781d86d560e1fc2735115be834
 RUN GOEXPERIMENT=strictfipsruntime,boringcrypto CGO_ENABLED=1 GOBIN=/go/bin go install -a -tags netgo -ldflags=-w
 
 # Final stage

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1747218906 AS base
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1751286687 AS base
 ARG TARGETARCH
 USER root
 RUN microdnf install -y tar gzip make which git gcc go-toolset

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -19,7 +19,7 @@ FROM base AS health-probe-builder
 WORKDIR /go/src/app
 RUN git clone https://github.com/authzed/grpc-health-probe.git
 WORKDIR /go/src/app/grpc-health-probe
-RUN git checkout 9c07eb880c5e87df5dc79dedb58fbc3ad12b2fd4
+RUN git checkout 9d30dbbc7936d5fff08d4cf6abc6444777977b39
 RUN GOEXPERIMENT=strictfipsruntime,boringcrypto CGO_ENABLED=1 GOBIN=/go/bin go install -a -tags netgo -ldflags=-w
 
 # Final stage


### PR DESCRIPTION
Spicedb image was failing causing builds in relations to fail. Updating rpms-signature-scan task

- ubi base image update
- grpc-health-probe hash version updated inline with repo go version
- rpms-signature-scan task updated to latest