### PR TITLE
RHCLOUD-43818: adds README-redhat.md to capture changes in our fork from upstream

### DIFF
--- a/README-redhat.md
+++ b/README-redhat.md
@@ -12,12 +12,12 @@ The table below captures high level changes to our fork from upstream and the re
 |------|------|
 |Dependabot intervals changed to daily |This better aligns with other Kessel Services|
 |All active workflows defined by Authzed updated use the `ubuntu-latest` image for the runner|Authzed uses a custom self-hosted runner in their workflows which we don't have access to|
-|Non-critical workflows disabled or removed|Workflows that do not impact code functionality or Red Hat builds are disabled. This includes: benchmark, analyzer unit, WASM, and Steelthread tests, binary and image builds (using upstream Dockerfile), datastore integration/consistency tests for mysql, spanner, and cockaroach DB, documentation generation, lint checks, license checks, release pipelines, CodeQL and Trivy scanning, and WASM builds|
+|Non-critical workflows disabled or removed|Workflows that do not impact code functionality or Red Hat builds are disabled.<br><br> This includes:<br> * Benchmark, analyzer unit, WASM, and Steelthread tests<br> * Binary and image builds (using upstream Dockerfile)<br> * Datastore integration & consistency tests for MySQL, Spanner, and CockroachDB<br> * Documentation generation<br> * Lint checks<br> * License checks<br> * Release pipelines<br> * CodeQL and Trivy scanning<br> * WASM builds|
 |Removed old versions of Postgres from Datastore integration/consistency workflows| Tests are isolated to version we currently use (16/17)|
 |Added the security scanning workflow|Required ConsoleDot platform security workflow to check for CVE's in code and images|
 |Added push/pull tekton pipelines|Used for Konflux PR and merge builds|
 |Added Dockerfile.fips|Dockerfile used by Konflux for building images, to comply with requirements of using UBI as the base image, and to ensure FIPS-compliant builds using Go Toolset|
-|Updated integration and unit test timeout values|Integration and unit tests were failing due short timeouts, likely related to using smaller runners than Authzed may be using. These code changes can be found in the `magefiles/test.go` file|
+|Updated integration and unit test timeout values|Integration and unit tests were failing due to short timeouts, likely related to using smaller runners than Authzed may be using. These code changes can be found in the `magefiles/test.go` file|
 
 &nbsp;
 
@@ -30,7 +30,7 @@ To comply with [Red Hat Software Certification policies](https://docs.redhat.com
 
 **Go Toolset**
 
-To ensure FIPS compliant binaries for running in FedRAMP environments, we leverage Go Toolset vs upstream Go for all builds. While upstream Go is currently [working on FIP 140-3 certification](https://go.dev/blog/fips140), these modules are still in process and under review and therefore are not validated nor shipped with any RHEL products including UBI based images.
+To ensure FIPS compliant binaries for running in FedRAMP environments, we leverage Go Toolset vs upstream Go for all builds. While upstream Go is currently [working on FIPS 140-3 certification](https://go.dev/blog/fips140), these modules are still in process and under review and therefore are not validated nor shipped with any RHEL products including UBI based images.
 
 Go Toolset leverages a fork of Go which is based on the upstream work to enable Go to link against the C library Boring Crypto. This fork uses OpenSSL instead of BoringSSL which is already FIPS validated on RHEL systems (hence the reliance on specific versions of UBI such as 9.x). When upstream Go has finished FIPS validation, it is expected that Go Toolset will converge to using upstream Go and will remain our install target long term on UBI images.
 

--- a/README-redhat.md
+++ b/README-redhat.md
@@ -1,0 +1,58 @@
+# Information about Red Hat's Fork of SpiceDB
+
+This document captures all changes made by Red Hat that diverge from the upstream fork. It outlines why these changes were made for historical reference and to help ensure they are kept when syncing with upstream.
+
+&nbsp;
+
+### Drift Tracking
+
+The table below captures high level changes to our fork from upstream and the reason for these changes.
+
+|Change|Reason|
+|------|------|
+|Dependabot intervals changed to daily |This better aligns with other Kessel Services|
+|All active workflows defined by Authzed updated use the `ubuntu-latest` image for the runner|Authzed uses a custom self-hosted runner in their workflows which we don't have access to|
+|Non-critical workflows disabled or removed|Workflows that do not impact code functionality or Red Hat builds are disabled. This includes: benchmark, analyzer unit, WASM, and Steelthread tests, binary and image builds (using upstream Dockerfile), datastore integration/consistency tests for mysql, spanner, and cockaroach DB, documentation generation, lint checks, license checks, release pipelines, CodeQL and Trivy scanning, and WASM builds|
+|Removed old versions of Postgres from Datastore integration/consistency workflows| Tests are isolated to version we currently use (16/17)|
+|Added the security scanning workflow|Required ConsoleDot platform security workflow to check for CVE's in code and images|
+|Added push/pull tekton pipelines|Used for Konflux PR and merge builds|
+|Added Dockerfile.fips|Dockerfile used by Konflux for building images, to comply with requirements of using UBI as the base image, and to ensure FIPS-compliant builds using Go Toolset|
+|Updated integration and unit test timeout values|Integration and unit tests were failing due short timeouts, likely related to using smaller runners than Authzed may be using. These code changes can be found in the `magefiles/test.go` file|
+
+&nbsp;
+
+### More on our Dockerfile and Builds
+
+**UBI Base Images**
+
+To comply with [Red Hat Software Certification policies](https://docs.redhat.com/en/documentation/red_hat_software_certification/2025/html-single/red_hat_openshift_software_certification_policy_guide/index#con-image-content-requirements_openshift-sw-cert-policy-container-images), UBI images are used as the base image for both building and running the container image. This ensures images are built to Red Hat security standards, comply with our build processes, and ensures that application runtime dependencies, such as operating system components and libraries, are covered under the customer’s subscription (where applicable). Our current UBI base image specifically targets RHEL 9.x to ensure it contains [FIPS-validated cryptographic modules](https://access.redhat.com/compliance/fips) for running in FedRAMP environments.
+
+
+**Go Toolset**
+
+To ensure FIPS compliant binaries for running in FedRAMP environments, we leverage Go Toolset vs upstream Go for all builds. While upstream Go is currently [working on FIP 140-3 certification](https://go.dev/blog/fips140), these modules are still in process and under review and therefore are not validated nor shipped with any RHEL products including UBI based images.
+
+Go Toolset leverages a fork of Go which is based on the upstream work to enable Go to link against the C library Boring Crypto. This fork uses OpenSSL instead of BoringSSL which is already FIPS validated on RHEL systems (hence the reliance on specific versions of UBI such as 9.x). When upstream Go has finished FIPS validation, it is expected that Go Toolset will converge to using upstream Go and will remain our install target long term on UBI images.
+
+**Go and Base Image Updates**
+
+With our reliance on Go Toolset and FIPS-validated OpenSSL modules, our ability to sync upstream code changes can be limited due to Go versions used upstream. The version of Go listed in our `go.mod` file must not be greater than the [latest version](https://catalog.redhat.com/en/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690) of Go Toolset available for the specific UBI version in use. This is required to remain FIPS compliant and have FIPS-validated OpenSSL modules. Base images must also be updated with care to ensure only validated versions of RHEL are used.
+
+For more info on Go Toolset and FIPS certifications at Red Hat:
+* [Golang-FIPS](https://github.com/golang-fips/go/blob/main/README.md)
+* [FIPS Mode for Red Hat Go Toolset](https://developers.redhat.com/articles/2025/01/23/fips-mode-red-hat-go-toolset)
+* [Red Hat FIPS Compliance](https://access.redhat.com/compliance/fips)
+
+&nbsp;
+
+### Updating this File
+
+If changes are made to our fork that diverge from upstream that are not captured in this README, make sure to update this file with any relevant changes. Be sure to capture the change and reason in the table above.
+
+An easy way to capture differences is to use `git diff` and compare your synced branch to the upstream tag branch to see all differences between upstream and the current state.
+
+```bash
+# assumes you have an `upstream` remote for the upstream source code
+git checkout -b upstream-<tag> tags/<tag>
+git diff upstream-<tag>..<your-synced-branch>
+```


### PR DESCRIPTION
Adds a red hat specific readme to capture changes in our fork that diverge from upstream and the reason for the change. This also includes our use of UBI and go toolset.