### PR TITLE
fixes renovate cron schedule, minor update to README-redhat about renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
   "packageRules": [
     {
       "matchManagers": ["dockerfile"],
-      "schedule": ["0 0 * * 0"]
+      "schedule": ["* 0-1 * * 0"]
     }
   ]
 }

--- a/README-redhat.md
+++ b/README-redhat.md
@@ -11,7 +11,7 @@ The table below captures high-level changes to our fork from upstream and the re
 |Change|Reason|
 |------|------|
 |The `dependabot.yml` file has been removed to disable Dependabot|This better aligns with other Red Hat mandates to leverage Konflux|
-|Added the `renovate.json` file|This configures Mintmaker (part of Konflux) to prevent Go pkg update PRs and move to weekly updates for Dockerfile base image updates|
+|Removes Authzed's `renovate.json` and replaces it with our own|This configures Mintmaker (part of Konflux) to prevent Go pkg update PRs and move to weekly updates for Dockerfile base image updates|
 |All active workflows defined by Authzed updated use the `ubuntu-latest` image for the runner|Authzed uses a custom self-hosted runner in their workflows which we don't have access to|
 |Non-critical workflows disabled or removed|Workflows that do not impact code functionality or Red Hat builds are disabled.<br><br> This includes:<br> * Benchmark, analyzer unit, WASM, and Steelthread tests<br> * Binary and image builds (using upstream Dockerfile)<br> * Datastore integration & consistency tests for MySQL, Spanner, and CockroachDB<br> * Documentation generation<br> * Lint checks<br> * License checks<br> * Release pipelines<br> * CodeQL and Trivy scanning<br> * WASM builds|
 |Removed old versions of Postgres from Datastore integration/consistency workflows| Tests are isolated to version we currently use (16/17)|


### PR DESCRIPTION
## Describe your changes
Related to issue in Inventory API: https://github.com/project-kessel/inventory-api/issues/1271

* Fixes issue with the cron schedule in our renovate.json
* Adds note to README-redhat that our renovate.json replaces the upstream one as they also use renovate

```shell
# requires `npm install renovate` first if you dont have it
$ npx --yes renovate-config-validator
 INFO: Validating .github/renovate.json
ERROR: Found errors in configuration
       "file": ".github/renovate.json",
       "errors": [
         {
           "topic": "Configuration Error",
           "message": "Invalid packageRules[0].schedule: `Invalid schedule: \"0 0 * * 0\" has cron syntax, but doesn't have * as minutes`"
         }
       ]
```

Per docs:
> For Cron schedules, you must use the * wildcard for the minutes value, as Renovate doesn't support minute granularity. 

The updated schedule will allow mintmaker PR's between midnight and 2am on Sundays only, still effectively reducing the frequency of PR's, allowing for SM's to catch up during the week.

### Validation
```shell
$ npx --yes renovate-config-validator
 INFO: Validating .github/renovate.json
 INFO: Config validated successfully
```