### PR TITLE
RHCLOUD-44400: Updates to improve the fork syncing process

### DIFF
--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: sync-upstream
+description: Sync the SpiceDB fork from upstream. Determines the latest supported SpiceDB version from the operator's update graph, validates the upgrade path, and syncs if a new version is available.
+disable-model-invocation: true
+argument-hint: [--tag <tag>]
+---
+
+# Sync SpiceDB from Upstream
+
+Syncs this fork from upstream [authzed/spicedb](https://github.com/authzed/spicedb)
+by determining the latest supported version from the SpiceDB Operator's update graph.
+
+## Arguments
+
+- `--tag <tag>` — (optional) override the SpiceDB tag to sync to. If omitted,
+  the skill determines the latest supported version from the operator's update graph.
+
+## GitHub URLs
+
+The skill uses these URLs to fetch operator data without needing the operator repo
+locally:
+
+- **Operator SYNC.md**: `https://raw.githubusercontent.com/project-kessel/spicedb-operator/refs/heads/main/SYNC.md`
+- **Update graph**: `https://raw.githubusercontent.com/project-kessel/spicedb-operator/refs/heads/main/config/update-graph.yaml`
+
+## Process
+
+### Step 1: Determine the Target Tag
+
+If `--tag` was provided, use that and skip to Step 2.
+
+Otherwise, determine the latest supported SpiceDB version:
+
+1. Check if `validate-upgrade-path` is in PATH:
+   ```bash
+   which validate-upgrade-path
+   ```
+
+2. **If the tool IS available**, use it with the GitHub URL to list versions:
+   ```bash
+   validate-upgrade-path \
+     -g https://raw.githubusercontent.com/project-kessel/spicedb-operator/refs/heads/main/config/update-graph.yaml \
+     --list-versions -d postgres
+   ```
+   The **first version listed** is the latest supported SpiceDB version.
+
+3. **If the tool is NOT available**, ask the user:
+   > `validate-upgrade-path` is not installed. Please provide either:
+   > - The path to your spicedb-operator repo so I can build and run it, or
+   > - The SpiceDB tag to sync to using `--tag`
+   >
+   > To install the tool: `cd <spicedb-operator-repo> && make install-validate-upgrade-path`
+
+   If the user provides the operator repo path:
+   ```bash
+   cd <operator-repo> && make build-validate-upgrade-path
+   bin/validate-upgrade-path --list-versions -d postgres
+   ```
+
+4. Read the current SpiceDB version from this repo's `SYNC.md`
+
+5. If the latest version matches the current version, report that SpiceDB is
+   already up to date and stop
+
+6. Validate the upgrade path from current to latest:
+   ```bash
+   validate-upgrade-path \
+     -g https://raw.githubusercontent.com/project-kessel/spicedb-operator/refs/heads/main/config/update-graph.yaml \
+     <current-version> <latest-version>
+   ```
+
+7. If the upgrade is NOT supported, report the finding and stop — ask the user
+   how to proceed
+
+**Important**: Before proceeding, check the `go` directive in the upstream
+`go.mod` at the target tag:
+```bash
+git fetch upstream --tags
+git show tags/<tag>:go.mod | head -5
+```
+If the Go version exceeds our go-toolset version, stop and report the issue.
+The current go-toolset version constraint is documented in `README-redhat.md`.
+
+### Step 2: Sync
+
+1. `git fetch upstream --tags` (if not already done)
+2. `git checkout -b sync-upstream-<tag> tags/<tag>`
+3. `git checkout -b merge-upstream-<tag> main`
+4. `git merge sync-upstream-<tag>`
+5. Resolve any merge conflicts using the **Merge Action** column in the drift
+   tracking table in `README-redhat.md`
+6. For `go.mod` and `go.sum` conflicts, reset to upstream entirely:
+   `git checkout sync-upstream-<tag> -- <all go.mod and go.sum files with conflicts>`
+7. For any file not listed in the table, accept the upstream (incoming) version
+
+### Step 3: Update SYNC.md
+
+Update `SYNC.md` with the new tag and the commit SHA of the upstream tag:
+```bash
+git rev-parse tags/<tag>
+```
+Commit the update.
+
+### Step 4: Post-Merge Cleanup
+
+1. Run `./scripts/redhat-diff.sh --stat`
+2. Remove any **stale files** listed in the warning:
+   ```bash
+   git rm <file1> <file2> ...
+   ```
+3. Reset any **diverged files** listed in the warning:
+   ```bash
+   git checkout tags/<tag> -- <file1> <file2> ...
+   ```
+4. Commit the cleanup
+5. Re-run `./scripts/redhat-diff.sh --stat` to confirm clean output
+
+### Step 5: Push and Create PR
+
+1. Push the branch:
+   ```bash
+   git push origin merge-upstream-<tag>
+   ```
+2. Create a PR to main (**do not squash commits**)
+3. Post the Red Hat diff on the PR:
+   ```bash
+   ./scripts/redhat-diff.sh --pr <pr-number>
+   ```
+
+### Step 6: Summary
+
+Report:
+- Old tag → new tag
+- Upgrade path validation result (steps and migrations required)
+- PR link
+- Number of Red Hat changes, stale files cleaned, diverged files reset
+- Remind the user to review the PR and check CI before merging
+- Note: this PR should be merged BEFORE the operator PR, since the operator
+  depends on the SpiceDB image being built and available

--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -90,7 +90,13 @@ The current go-toolset version constraint is documented in `README-redhat.md`.
 5. Resolve any merge conflicts using the **Merge Action** column in the drift
    tracking table in `README-redhat.md`
 6. For `go.mod` and `go.sum` conflicts, reset to upstream entirely:
-   `git checkout sync-upstream-<tag> -- <all go.mod and go.sum files with conflicts>`
+   ```bash
+   # Find all conflicting go.mod/go.sum/go.work files
+   git diff --name-only --diff-filter=U --relative | grep -E "mod|sum|work"
+
+   # Reset them to the upstream version
+   git checkout sync-upstream-<tag> -- <file1> <file2> ...
+   ```
 7. For any file not listed in the table, accept the upstream (incoming) version
 
 ### Step 3: Update SYNC.md

--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -76,7 +76,7 @@ Otherwise, determine the latest supported SpiceDB version:
 `go.mod` at the target tag:
 ```bash
 git fetch upstream --tags
-git show tags/<tag>:go.mod | head -5
+git show tags/<tag>:go.mod | grep -E '^go '
 ```
 If the Go version exceeds our go-toolset version, stop and report the issue.
 The current go-toolset version constraint is documented in `README-redhat.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ manpages/
 .env.local
 coverage*.txt
 .idea/
-.claude/
+.claude/settings.local.json
 e2e/newenemy/spicedb
 e2e/newenemy/cockroach
 e2e/newenemy/chaosd

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,11 @@ new files introduced by upstream.
 **For `go.mod` and `go.sum` conflicts**: do not resolve these line-by-line. Instead,
 reset all `go.mod` and `go.sum` files to the upstream version entirely:
 ```
-git checkout sync-upstream-<tag> -- <all go.mod and go.sum files with conflicts>
+# Find all conflicting go.mod/go.sum/go.work files
+git diff --name-only --diff-filter=U --relative | grep -E "mod|sum|work"
+
+# Reset them to the upstream version
+git checkout sync-upstream-<tag> -- <file1> <file2> ...
 ```
 This ensures Go dependencies stay aligned with upstream, since git auto-merges
 non-conflicting lines and may preserve newer dependency versions from our fork

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md — SpiceDB Fork (Red Hat)
+
+This is Red Hat's fork of [authzed/spicedb](https://github.com/authzed/spicedb).
+See `README-redhat.md` for a full list of Red Hat-specific changes and their rationale.
+
+## Upstream Sync Process
+
+This fork is periodically synced from upstream using a merge-based workflow.
+See `SYNC.md` for the currently synced upstream tag.
+
+### Merge Conflict Resolution Rules
+
+When merging upstream changes, resolve conflicts using the **Merge Action** column
+in the drift tracking table in `README-redhat.md`. The four actions are:
+
+- **Keep ours**: always preserve the Red Hat version of this file
+- **Re-apply**: accept upstream changes, then re-apply our specific modifications
+  (e.g., change runners to `ubuntu-latest`, add `if: false`, restore our timeout values)
+- **Delete**: file should not exist in our fork; remove if upstream re-adds it
+- **Red Hat only**: file exists only in our fork; no upstream equivalent — keep as-is
+
+**For all other files not listed in the table**: accept the upstream (incoming) version.
+This includes all Go source code, `go.mod`, `go.sum`, protobuf definitions, and any
+new files introduced by upstream.
+
+**For `go.mod` and `go.sum` conflicts**: do not resolve these line-by-line. Instead,
+reset all `go.mod` and `go.sum` files to the upstream version entirely:
+```
+git checkout sync-upstream-<tag> -- <all go.mod and go.sum files with conflicts>
+```
+This ensures Go dependencies stay aligned with upstream, since git auto-merges
+non-conflicting lines and may preserve newer dependency versions from our fork
+that we no longer maintain independently.
+
+### Workflow Runner Mappings
+
+When upstream introduces or modifies workflows we keep, replace their runner with ours:
+- `depot-*`, `buildjet-*`, or any custom runner → `ubuntu-latest`
+
+### Post-Merge Cleanup
+
+After the merge completes, run `./scripts/redhat-diff.sh --stat` to check for:
+- **Stale files**: upstream deleted/renamed files that survived the merge — remove them
+- **Diverged files**: upstream files where the merge produced different content — reset
+  them with `git checkout tags/<tag> -- <file>`
+- **Red Hat changes**: the actual changes to review

--- a/README-redhat.md
+++ b/README-redhat.md
@@ -6,19 +6,40 @@ This document captures all changes made by Red Hat that diverge from the upstrea
 
 ### Drift Tracking
 
-The table below captures high-level changes to our fork from upstream and the reason for these changes.
+The table below captures all changes to our fork from upstream. Each entry includes the affected files, what changed, why, and how to handle conflicts during upstream syncs.
 
-|Change|Reason|
-|------|------|
-|The `dependabot.yml` file has been removed to disable Dependabot|This better aligns with other Red Hat mandates to leverage Konflux|
-|Removes Authzed's `renovate.json` and replaces it with our own|This configures Mintmaker (part of Konflux) to prevent Go pkg update PRs and move to weekly updates for Dockerfile base image updates|
-|All active workflows defined by Authzed updated use the `ubuntu-latest` image for the runner|Authzed uses a custom self-hosted runner in their workflows which we don't have access to|
-|Non-critical workflows disabled or removed|Workflows that do not impact code functionality or Red Hat builds are disabled.<br><br> This includes:<br> * Benchmark, analyzer unit, WASM, and Steelthread tests<br> * Binary and image builds (using upstream Dockerfile)<br> * Datastore integration & consistency tests for MySQL, Spanner, and CockroachDB<br> * Documentation generation<br> * Lint checks<br> * License checks<br> * Release pipelines<br> * CodeQL and Trivy scanning<br> * WASM builds * Changelog workflow * Protobuf Generation|
-|Removed old versions of Postgres from Datastore integration/consistency workflows| Tests are isolated to version we currently use (16/17)|
-|Added the security scanning workflow|Required ConsoleDot platform security workflow to check for CVE's in code and images|
-|Added push/pull tekton pipelines|Used for Konflux PR and merge builds|
-|Added Dockerfile.fips|Dockerfile used by Konflux for building images, to comply with requirements of using UBI as the base image, and to ensure FIPS-compliant builds using Go Toolset|
-|Updated integration and unit test timeout values|Integration and unit tests were failing due to short timeouts, likely related to using smaller runners than Authzed may be using. These code changes can be found in the `magefiles/test.go` file|
+**Merge actions:**
+- **Keep ours**: always preserve the Red Hat version of this file
+- **Re-apply**: accept upstream changes, then re-apply our specific modifications
+- **Delete**: file should not exist in our fork; remove if upstream re-adds it
+- **Red Hat only**: file exists only in our fork; no upstream equivalent
+
+| File(s) | Change | Reason | Merge Action |
+|---------|--------|--------|-------------|
+| `.github/dependabot.yml` | Removed | Aligns with Red Hat mandates to leverage Konflux | Delete |
+| `.github/renovate.json` | Replaced with our own config | Configures Mintmaker (part of Konflux) to prevent Go pkg update PRs and move to weekly updates for Dockerfile base image updates | Keep ours |
+| Active workflows in `.github/workflows/` | Runner changed to `ubuntu-latest` | Authzed uses custom self-hosted runners (`depot-*`, `buildjet-*`) which we don't have access to | Re-apply |
+| `.github/workflows/build-test.yaml` | Disabled: build, steelthread, analyzer-unit, WASM, protobuf, benchmark jobs (`if: false`); disabled CockroachDB/MySQL/Spanner datastore tests; changed `Dockerfile` reference to `Dockerfile.fips`; limited Postgres versions to 16/17 | Non-critical to Red Hat builds or not applicable to our deployment targets | Re-apply |
+| `.github/workflows/benchmark.yaml` | Disabled (`if: false`) | Not critical to Red Hat builds | Re-apply |
+| `.github/workflows/commit-messages.yaml` | Disabled (`if: false`) | Not critical to Red Hat builds | Re-apply |
+| `.github/workflows/docs.yaml` | Disabled (`if: false`) | Not critical to Red Hat builds | Re-apply |
+| `.github/workflows/keep-a-changelog.yaml` | Disabled (`if: false`) | Not critical to Red Hat builds | Re-apply |
+| `.github/workflows/lint.yaml` | Disabled (`if: false`) | Not critical to Red Hat builds | Re-apply |
+| `.github/workflows/release-windows.yaml` | Disabled (`if: false`) | Not critical to Red Hat builds | Re-apply |
+| `.github/workflows/cla.yaml` | Removed | Not applicable to our fork | Delete |
+| `.github/workflows/labeler.yaml` | Removed | Not applicable to our fork | Delete |
+| `.github/workflows/nightly.yaml` | Removed | Not applicable to our fork | Delete |
+| `.github/workflows/release.yaml` | Removed | Not applicable to our fork | Delete |
+| `.github/workflows/security.yaml` | Removed | Replaced by our own security scanning workflow | Delete |
+| `.github/workflows/wasm.yaml` | Removed | Not applicable to our fork | Delete |
+| `.github/workflows/security-scanning.yml` | Added | Required ConsoleDot platform security workflow for CVE scanning | Red Hat only |
+| `.tekton/spicedb-pull-request.yaml`, `.tekton/spicedb-push.yaml` | Added | Konflux PR and merge build pipelines | Red Hat only |
+| `Dockerfile.fips` | Added | FIPS-compliant builds using UBI base image and Go Toolset for Konflux | Red Hat only |
+| `magefiles/test.go` | Increased timeouts (unit: 20m, integration: 30m, consistency: 20m) | Tests fail with short timeouts on smaller runners | Re-apply |
+| `scripts/redhat-diff.sh` | Added | Script to isolate Red Hat-specific changes from upstream sync PRs for easier code review | Red Hat only |
+| `README-redhat.md` | Added | Documents all Red Hat fork changes and rationale | Red Hat only |
+| `SYNC.md` | Added | Tracks the current upstream version synced to this fork | Red Hat only |
+| `.yamllint` | Added | YAML linting configuration | Red Hat only |
 
 &nbsp;
 
@@ -63,10 +84,12 @@ Update `SYNC.md` as part of any PR that merges changes from the upstream [authze
 
 If changes are made to our fork that diverge from upstream that are not captured in this README, make sure to update this file with any relevant changes. Be sure to capture the change and reason in the table above.
 
-An easy way to capture differences is to use `git diff` and compare your synced branch to the upstream tag branch to see all differences between upstream and the current state.
+An easy way to capture differences is to use `scripts/redhat-diff.sh` which compares the merge branch against the upstream tag and shows only Red Hat-specific changes:
 
 ```bash
-# assumes you have an `upstream` remote for the upstream source code
-git checkout -b upstream-<tag> tags/<tag>
-git diff upstream-<tag>..<your-synced-branch>
+# Show summary of Red Hat changes for this sync
+./scripts/redhat-diff.sh --stat
+
+# Show all cumulative Red Hat changes vs upstream
+./scripts/redhat-diff.sh --all --stat
 ```

--- a/README-redhat.md
+++ b/README-redhat.md
@@ -37,6 +37,7 @@ The table below captures all changes to our fork from upstream. Each entry inclu
 | `Dockerfile.fips` | Added | FIPS-compliant builds using UBI base image and Go Toolset for Konflux | Red Hat only |
 | `magefiles/test.go` | Increased timeouts (unit: 20m, integration: 30m, consistency: 20m) | Tests fail with short timeouts on smaller runners | Re-apply |
 | `scripts/redhat-diff.sh` | Added | Script to isolate Red Hat-specific changes from upstream sync PRs for easier code review | Red Hat only |
+| `CLAUDE.md` | Replaced with our own | Contains Red Hat-specific merge conflict resolution rules for upstream syncs | Keep ours |
 | `README-redhat.md` | Added | Documents all Red Hat fork changes and rationale | Red Hat only |
 | `SYNC.md` | Added | Tracks the current upstream version synced to this fork | Red Hat only |
 | `.yamllint` | Added | YAML linting configuration | Red Hat only |

--- a/scripts/redhat-diff.sh
+++ b/scripts/redhat-diff.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+#
+# redhat-diff.sh - Show only Red Hat-specific changes introduced or modified during
+#                  an upstream sync, filtering out pure upstream changes and unchanged
+#                  Red Hat modifications.
+#
+# How it works:
+#   For each file that has Red Hat modifications on the merge branch, the script
+#   compares the "Red Hat delta" (diff from upstream tag) before and after the sync.
+#   Only files where this delta changed are shown — meaning the Red Hat-specific
+#   modifications were added, updated, or removed during this sync.
+#
+# Usage:
+#   ./scripts/redhat-diff.sh                    # print diff to stdout
+#   ./scripts/redhat-diff.sh --stat             # print diffstat summary only
+#   ./scripts/redhat-diff.sh --pr <number>      # post diff as a comment on a GitHub PR
+#   ./scripts/redhat-diff.sh --tag <tag>        # override the new tag from SYNC.md
+#   ./scripts/redhat-diff.sh --branch <branch>  # compare against a branch other than HEAD
+#   ./scripts/redhat-diff.sh --base <branch>    # base branch to compare from (default: main)
+#   ./scripts/redhat-diff.sh --all              # show cumulative Red Hat delta from upstream
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "Error: not inside a git repository" >&2
+    exit 1
+}
+SYNC_FILE="$REPO_ROOT/SYNC.md"
+
+# Defaults
+TAG=""
+BRANCH="HEAD"
+BASE="main"
+PR_NUMBER=""
+STAT_ONLY=false
+SHOW_ALL=false
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Show Red Hat-specific changes made during an upstream sync.
+
+By default, compares the Red Hat delta (diff from upstream) before and after
+the sync. Only files where the Red Hat modifications changed are shown.
+Use --all to show the full cumulative Red Hat delta from upstream.
+
+Options:
+  --tag <tag>        Override the upstream tag (default: read from SYNC.md on branch)
+  --branch <branch>  Branch to compare (default: HEAD)
+  --base <branch>    Base branch to compare from (default: main)
+  --stat             Show diffstat summary only
+  --all              Show all Red Hat changes vs upstream (cumulative)
+  --pr <number>      Post the diff as a comment on the given GitHub PR
+  -h, --help         Show this help message
+EOF
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tag)    TAG="$2"; shift 2 ;;
+        --branch) BRANCH="$2"; shift 2 ;;
+        --base)   BASE="$2"; shift 2 ;;
+        --stat)   STAT_ONLY=true; shift ;;
+        --all)    SHOW_ALL=true; shift ;;
+        --pr)
+            if ! command -v gh >/dev/null 2>&1; then
+                echo "Error: the --pr flag requires the GitHub CLI (gh) to be installed." >&2
+                echo "Install it from https://cli.github.com/" >&2
+                exit 1
+            fi
+            PR_NUMBER="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+# Read new tag from SYNC.md on the branch being compared
+read_tag_from_ref() {
+    local ref="$1"
+    git -C "$REPO_ROOT" show "$ref:SYNC.md" 2>/dev/null \
+        | sed -n 's/^TAG:[[:space:]]*//p' \
+        | tr -d '[:space:]'
+}
+
+if [[ -z "$TAG" ]]; then
+    TAG=$(read_tag_from_ref "$BRANCH")
+    if [[ -z "$TAG" ]]; then
+        echo "Error: could not parse TAG from SYNC.md on $BRANCH" >&2
+        exit 1
+    fi
+fi
+
+# Verify the new tag exists locally
+if ! git -C "$REPO_ROOT" rev-parse "tags/$TAG" >/dev/null 2>&1; then
+    echo "Error: tag '$TAG' not found. Run 'git fetch upstream --tags' first." >&2
+    exit 1
+fi
+
+# --all mode: show cumulative Red Hat delta
+if [[ "$SHOW_ALL" == true ]]; then
+    echo "Comparing $BRANCH against upstream tag: $TAG (all Red Hat changes)" >&2
+    if [[ "$STAT_ONLY" == true ]]; then
+        git -C "$REPO_ROOT" diff --stat "tags/$TAG..$BRANCH"
+    else
+        git -C "$REPO_ROOT" diff "tags/$TAG..$BRANCH"
+    fi
+    exit 0
+fi
+
+# Read old tag from SYNC.md on the base branch
+OLD_TAG=$(read_tag_from_ref "$BASE")
+if [[ -z "$OLD_TAG" ]]; then
+    echo "Error: could not parse TAG from SYNC.md on $BASE" >&2
+    exit 1
+fi
+
+if ! git -C "$REPO_ROOT" rev-parse "tags/$OLD_TAG" >/dev/null 2>&1; then
+    echo "Error: old tag '$OLD_TAG' not found. Run 'git fetch upstream --tags' first." >&2
+    exit 1
+fi
+
+echo "Comparing Red Hat delta: $BASE ($OLD_TAG) -> $BRANCH ($TAG)" >&2
+
+# Get all files that have Red Hat modifications on either side
+ALL_RH_FILES=$(
+    {
+        git -C "$REPO_ROOT" diff --name-only "tags/$TAG..$BRANCH"
+        git -C "$REPO_ROOT" diff --name-only "tags/$OLD_TAG..$BASE"
+    } | sort -u
+)
+
+if [[ -z "$ALL_RH_FILES" ]]; then
+    echo "No Red Hat-specific changes found." >&2
+    exit 0
+fi
+
+# Extract only the added/removed lines from a diff, stripping headers,
+# hunk markers, and context lines so that comparisons are not thrown off
+# by shifted line numbers or changed surrounding context.
+diff_essence() {
+    { grep -E '^\+[^+]|^-[^-]' || true; } | sort
+}
+
+# Check if a file exists at a given git ref
+file_exists_at_ref() {
+    git -C "$REPO_ROOT" cat-file -t "$1:$2" >/dev/null 2>&1
+}
+
+# Compare the Red Hat delta for each file before and after the sync.
+# Only include files where the substantive delta changed.
+# Also detect merge artifacts: files that upstream deleted/renamed but
+# survived the merge.
+CHANGED_FILES=()
+STALE_FILES=()
+DIVERGED_FILES=()
+while IFS= read -r file; do
+    # Detect stale files: file exists on merge branch but was removed/renamed
+    # upstream (not in new tag) and was an upstream file (existed in old tag).
+    # These are not Red Hat changes — they should have been removed by the merge.
+    if ! file_exists_at_ref "tags/$TAG" "$file" && file_exists_at_ref "tags/$OLD_TAG" "$file"; then
+        STALE_FILES+=("$file")
+        continue
+    fi
+
+    old_delta=$(git -C "$REPO_ROOT" diff "tags/$OLD_TAG..$BASE" -- "$file" | diff_essence)
+    new_delta=$(git -C "$REPO_ROOT" diff "tags/$TAG..$BRANCH" -- "$file" | diff_essence)
+
+    if [[ "$old_delta" != "$new_delta" ]]; then
+        # If the file had no Red Hat delta before but now differs from upstream,
+        # and the file exists on the upstream tag, it's a merge artifact — the
+        # merge produced content that doesn't match upstream exactly.
+        if [[ -z "$old_delta" ]] && [[ -n "$new_delta" ]] && file_exists_at_ref "tags/$TAG" "$file"; then
+            DIVERGED_FILES+=("$file")
+            continue
+        fi
+        CHANGED_FILES+=("$file")
+    fi
+done <<< "$ALL_RH_FILES"
+
+# Warn about stale files (upstream deleted/renamed but still on merge branch)
+if [[ ${#STALE_FILES[@]} -gt 0 ]]; then
+    echo "" >&2
+    echo "WARNING: The following files were deleted or renamed upstream but still" >&2
+    echo "exist on the merge branch. These may need to be removed:" >&2
+    for f in "${STALE_FILES[@]}"; do
+        echo "  - $f" >&2
+    done
+    echo "" >&2
+fi
+
+# Warn about diverged files (merge produced content that differs from upstream)
+if [[ ${#DIVERGED_FILES[@]} -gt 0 ]]; then
+    echo "WARNING: The following files diverged from upstream during the merge." >&2
+    echo "These are not Red Hat changes but the merge produced content that" >&2
+    echo "doesn't match upstream. Consider resetting them to the upstream version:" >&2
+    for f in "${DIVERGED_FILES[@]}"; do
+        echo "  - $f" >&2
+    done
+    echo "  To fix: git checkout tags/$TAG -- <file>" >&2
+    echo "" >&2
+fi
+
+if [[ ${#CHANGED_FILES[@]} -eq 0 ]]; then
+    echo "No Red Hat-specific changes for this sync." >&2
+    exit 0
+fi
+
+# Generate the output: show the NEW Red Hat delta for changed files
+if [[ "$STAT_ONLY" == true ]]; then
+    git -C "$REPO_ROOT" diff --stat "tags/$TAG..$BRANCH" -- "${CHANGED_FILES[@]}"
+    exit 0
+fi
+
+DIFF_OUTPUT=$(git -C "$REPO_ROOT" diff "tags/$TAG..$BRANCH" -- "${CHANGED_FILES[@]}")
+
+if [[ -z "$DIFF_OUTPUT" ]]; then
+    echo "No Red Hat-specific changes for this sync." >&2
+    exit 0
+fi
+
+# Post to PR or print to stdout
+if [[ -n "$PR_NUMBER" ]]; then
+    STAT_OUTPUT=$(git -C "$REPO_ROOT" diff --stat "tags/$TAG..$BRANCH" -- "${CHANGED_FILES[@]}")
+
+    WARNINGS_SECTION=""
+    if [[ ${#STALE_FILES[@]} -gt 0 ]]; then
+        STALE_LIST=""
+        for f in "${STALE_FILES[@]}"; do
+            STALE_LIST+=$'\n'"- \`$f\`"
+        done
+        WARNINGS_SECTION+=$(cat <<STALE
+
+### :warning: Stale files (upstream deleted/renamed)
+
+The following files were deleted or renamed upstream between \`$OLD_TAG\` and \`$TAG\`
+but still exist on this branch. They may need to be removed:
+$STALE_LIST
+
+STALE
+        )
+    fi
+
+    if [[ ${#DIVERGED_FILES[@]} -gt 0 ]]; then
+        DIVERGED_LIST=""
+        for f in "${DIVERGED_FILES[@]}"; do
+            DIVERGED_LIST+=$'\n'"- \`$f\`"
+        done
+        WARNINGS_SECTION+=$(cat <<DIVERGED
+
+### :warning: Diverged files (merge artifacts)
+
+The following files have no intentional Red Hat modifications but diverged from
+upstream during the merge. Consider resetting them: \`git checkout tags/$TAG -- <file>\`
+$DIVERGED_LIST
+
+DIVERGED
+        )
+    fi
+
+    COMMENT_BODY=$(cat <<EOF
+## Red Hat-specific changes (vs upstream \`$TAG\`)
+
+These are the Red Hat-specific changes that were added or modified in this sync.
+Reviewers: focus your review on these changes -- everything else is from upstream
+or unchanged Red Hat modifications.
+
+Previously synced to: \`$OLD_TAG\`
+$WARNINGS_SECTION
+### Summary
+\`\`\`
+$STAT_OUTPUT
+\`\`\`
+
+<details>
+<summary>Full diff (click to expand)</summary>
+
+\`\`\`diff
+$DIFF_OUTPUT
+\`\`\`
+
+</details>
+EOF
+    )
+
+    echo "Posting Red Hat diff to PR #$PR_NUMBER..." >&2
+    gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY" --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+    echo "Done. Comment posted to PR #$PR_NUMBER." >&2
+else
+    echo "$DIFF_OUTPUT"
+fi

--- a/scripts/redhat-diff.sh
+++ b/scripts/redhat-diff.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+#
+# redhat-diff.sh - Show only Red Hat-specific changes introduced or modified during
+#                  an upstream sync, filtering out pure upstream changes and unchanged
+#                  Red Hat modifications.
+#
+# How it works:
+#   For each file that has Red Hat modifications on the merge branch, the script
+#   compares the "Red Hat delta" (diff from upstream tag) before and after the sync.
+#   Only files where this delta changed are shown — meaning the Red Hat-specific
+#   modifications were added, updated, or removed during this sync.
+#
+# Usage:
+#   ./scripts/redhat-diff.sh                    # print diff to stdout
+#   ./scripts/redhat-diff.sh --stat             # print diffstat summary only
+#   ./scripts/redhat-diff.sh --pr <number>      # post diff as a comment on a GitHub PR
+#   ./scripts/redhat-diff.sh --tag <tag>        # override the new tag from SYNC.md
+#   ./scripts/redhat-diff.sh --branch <branch>  # compare against a branch other than HEAD
+#   ./scripts/redhat-diff.sh --base <branch>    # base branch to compare from (default: main)
+#   ./scripts/redhat-diff.sh --all              # show cumulative Red Hat delta from upstream
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "Error: not inside a git repository" >&2
+    exit 1
+}
+SYNC_FILE="$REPO_ROOT/SYNC.md"
+
+# Defaults
+TAG=""
+BRANCH="HEAD"
+BASE="main"
+PR_NUMBER=""
+STAT_ONLY=false
+SHOW_ALL=false
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Show Red Hat-specific changes made during an upstream sync.
+
+By default, compares the Red Hat delta (diff from upstream) before and after
+the sync. Only files where the Red Hat modifications changed are shown.
+Use --all to show the full cumulative Red Hat delta from upstream.
+
+Options:
+  --tag <tag>        Override the upstream tag (default: read from SYNC.md on branch)
+  --branch <branch>  Branch to compare (default: HEAD)
+  --base <branch>    Base branch to compare from (default: main)
+  --stat             Show diffstat summary only
+  --all              Show all Red Hat changes vs upstream (cumulative)
+  --pr <number>      Post the diff as a comment on the given GitHub PR
+  -h, --help         Show this help message
+EOF
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tag)    TAG="$2"; shift 2 ;;
+        --branch) BRANCH="$2"; shift 2 ;;
+        --base)   BASE="$2"; shift 2 ;;
+        --stat)   STAT_ONLY=true; shift ;;
+        --all)    SHOW_ALL=true; shift ;;
+        --pr)
+            if ! command -v gh >/dev/null 2>&1; then
+                echo "Error: the --pr flag requires the GitHub CLI (gh) to be installed." >&2
+                echo "Install it from https://cli.github.com/" >&2
+                exit 1
+            fi
+            PR_NUMBER="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+# Read new tag from SYNC.md on the branch being compared
+read_tag_from_ref() {
+    local ref="$1"
+    git -C "$REPO_ROOT" show "$ref:SYNC.md" 2>/dev/null \
+        | sed -n 's/^TAG:[[:space:]]*//p' \
+        | tr -d '[:space:]'
+}
+
+if [[ -z "$TAG" ]]; then
+    TAG=$(read_tag_from_ref "$BRANCH")
+    if [[ -z "$TAG" ]]; then
+        echo "Error: could not parse TAG from SYNC.md on $BRANCH" >&2
+        exit 1
+    fi
+fi
+
+# Verify the new tag exists locally
+if ! git -C "$REPO_ROOT" rev-parse "tags/$TAG" >/dev/null 2>&1; then
+    echo "Error: tag '$TAG' not found. Run 'git fetch authzed --tags' first." >&2
+    exit 1
+fi
+
+# --all mode: show cumulative Red Hat delta
+if [[ "$SHOW_ALL" == true ]]; then
+    echo "Comparing $BRANCH against upstream tag: $TAG (all Red Hat changes)" >&2
+    if [[ "$STAT_ONLY" == true ]]; then
+        git -C "$REPO_ROOT" diff --stat "tags/$TAG..$BRANCH"
+    else
+        git -C "$REPO_ROOT" diff "tags/$TAG..$BRANCH"
+    fi
+    exit 0
+fi
+
+# Read old tag from SYNC.md on the base branch
+OLD_TAG=$(read_tag_from_ref "$BASE")
+if [[ -z "$OLD_TAG" ]]; then
+    echo "Error: could not parse TAG from SYNC.md on $BASE" >&2
+    exit 1
+fi
+
+if ! git -C "$REPO_ROOT" rev-parse "tags/$OLD_TAG" >/dev/null 2>&1; then
+    echo "Error: old tag '$OLD_TAG' not found. Run 'git fetch authzed --tags' first." >&2
+    exit 1
+fi
+
+echo "Comparing Red Hat delta: $BASE ($OLD_TAG) -> $BRANCH ($TAG)" >&2
+
+# Get all files that have Red Hat modifications on either side
+ALL_RH_FILES=$(
+    {
+        git -C "$REPO_ROOT" diff --name-only "tags/$TAG..$BRANCH"
+        git -C "$REPO_ROOT" diff --name-only "tags/$OLD_TAG..$BASE"
+    } | sort -u
+)
+
+if [[ -z "$ALL_RH_FILES" ]]; then
+    echo "No Red Hat-specific changes found." >&2
+    exit 0
+fi
+
+# Extract only the added/removed lines from a diff, stripping headers,
+# hunk markers, and context lines so that comparisons are not thrown off
+# by shifted line numbers or changed surrounding context.
+diff_essence() {
+    { grep -E '^\+[^+]|^-[^-]' || true; } | sort
+}
+
+# Check if a file exists at a given git ref
+file_exists_at_ref() {
+    git -C "$REPO_ROOT" cat-file -t "$1:$2" >/dev/null 2>&1
+}
+
+# Compare the Red Hat delta for each file before and after the sync.
+# Only include files where the substantive delta changed.
+# Also detect merge artifacts: files that upstream deleted/renamed but
+# survived the merge.
+CHANGED_FILES=()
+STALE_FILES=()
+DIVERGED_FILES=()
+while IFS= read -r file; do
+    # Detect stale files: file exists on merge branch but was removed/renamed
+    # upstream (not in new tag) and was an upstream file (existed in old tag).
+    # These are not Red Hat changes — they should have been removed by the merge.
+    if ! file_exists_at_ref "tags/$TAG" "$file" && file_exists_at_ref "tags/$OLD_TAG" "$file"; then
+        STALE_FILES+=("$file")
+        continue
+    fi
+
+    old_delta=$(git -C "$REPO_ROOT" diff "tags/$OLD_TAG..$BASE" -- "$file" | diff_essence)
+    new_delta=$(git -C "$REPO_ROOT" diff "tags/$TAG..$BRANCH" -- "$file" | diff_essence)
+
+    if [[ "$old_delta" != "$new_delta" ]]; then
+        # If the file had no Red Hat delta before but now differs from upstream,
+        # and the file exists on the upstream tag, it's a merge artifact — the
+        # merge produced content that doesn't match upstream exactly.
+        if [[ -z "$old_delta" ]] && [[ -n "$new_delta" ]] && file_exists_at_ref "tags/$TAG" "$file"; then
+            DIVERGED_FILES+=("$file")
+            continue
+        fi
+        CHANGED_FILES+=("$file")
+    fi
+done <<< "$ALL_RH_FILES"
+
+# Warn about stale files (upstream deleted/renamed but still on merge branch)
+if [[ ${#STALE_FILES[@]} -gt 0 ]]; then
+    echo "" >&2
+    echo "WARNING: The following files were deleted or renamed upstream but still" >&2
+    echo "exist on the merge branch. These may need to be removed:" >&2
+    for f in "${STALE_FILES[@]}"; do
+        echo "  - $f" >&2
+    done
+    echo "" >&2
+fi
+
+# Warn about diverged files (merge produced content that differs from upstream)
+if [[ ${#DIVERGED_FILES[@]} -gt 0 ]]; then
+    echo "WARNING: The following files diverged from upstream during the merge." >&2
+    echo "These are not Red Hat changes but the merge produced content that" >&2
+    echo "doesn't match upstream. Consider resetting them to the upstream version:" >&2
+    for f in "${DIVERGED_FILES[@]}"; do
+        echo "  - $f" >&2
+    done
+    echo "  To fix: git checkout tags/$TAG -- <file>" >&2
+    echo "" >&2
+fi
+
+if [[ ${#CHANGED_FILES[@]} -eq 0 ]]; then
+    echo "No Red Hat-specific changes for this sync." >&2
+    exit 0
+fi
+
+# Generate the output: show the NEW Red Hat delta for changed files
+if [[ "$STAT_ONLY" == true ]]; then
+    git -C "$REPO_ROOT" diff --stat "tags/$TAG..$BRANCH" -- "${CHANGED_FILES[@]}"
+    exit 0
+fi
+
+DIFF_OUTPUT=$(git -C "$REPO_ROOT" diff "tags/$TAG..$BRANCH" -- "${CHANGED_FILES[@]}")
+
+if [[ -z "$DIFF_OUTPUT" ]]; then
+    echo "No Red Hat-specific changes for this sync." >&2
+    exit 0
+fi
+
+# Post to PR or print to stdout
+if [[ -n "$PR_NUMBER" ]]; then
+    STAT_OUTPUT=$(git -C "$REPO_ROOT" diff --stat "tags/$TAG..$BRANCH" -- "${CHANGED_FILES[@]}")
+
+    WARNINGS_SECTION=""
+    if [[ ${#STALE_FILES[@]} -gt 0 ]]; then
+        STALE_LIST=""
+        for f in "${STALE_FILES[@]}"; do
+            STALE_LIST+=$'\n'"- \`$f\`"
+        done
+        WARNINGS_SECTION+=$(cat <<STALE
+
+### :warning: Stale files (upstream deleted/renamed)
+
+The following files were deleted or renamed upstream between \`$OLD_TAG\` and \`$TAG\`
+but still exist on this branch. They may need to be removed:
+$STALE_LIST
+
+STALE
+        )
+    fi
+
+    if [[ ${#DIVERGED_FILES[@]} -gt 0 ]]; then
+        DIVERGED_LIST=""
+        for f in "${DIVERGED_FILES[@]}"; do
+            DIVERGED_LIST+=$'\n'"- \`$f\`"
+        done
+        WARNINGS_SECTION+=$(cat <<DIVERGED
+
+### :warning: Diverged files (merge artifacts)
+
+The following files have no intentional Red Hat modifications but diverged from
+upstream during the merge. Consider resetting them: \`git checkout tags/$TAG -- <file>\`
+$DIVERGED_LIST
+
+DIVERGED
+        )
+    fi
+
+    COMMENT_BODY=$(cat <<EOF
+## Red Hat-specific changes (vs upstream \`$TAG\`)
+
+These are the Red Hat-specific changes that were added or modified in this sync.
+Reviewers: focus your review on these changes -- everything else is from upstream
+or unchanged Red Hat modifications.
+
+Previously synced to: \`$OLD_TAG\`
+$WARNINGS_SECTION
+### Summary
+\`\`\`
+$STAT_OUTPUT
+\`\`\`
+
+<details>
+<summary>Full diff (click to expand)</summary>
+
+\`\`\`diff
+$DIFF_OUTPUT
+\`\`\`
+
+</details>
+EOF
+    )
+
+    echo "Posting Red Hat diff to PR #$PR_NUMBER..." >&2
+    gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY" --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+    echo "Done. Comment posted to PR #$PR_NUMBER." >&2
+else
+    echo "$DIFF_OUTPUT"
+fi

--- a/scripts/redhat-diff.sh
+++ b/scripts/redhat-diff.sh
@@ -94,7 +94,7 @@ fi
 
 # Verify the new tag exists locally
 if ! git -C "$REPO_ROOT" rev-parse "tags/$TAG" >/dev/null 2>&1; then
-    echo "Error: tag '$TAG' not found. Run 'git fetch authzed --tags' first." >&2
+    echo "Error: tag '$TAG' not found. Run 'git fetch upstream --tags' first." >&2
     exit 1
 fi
 
@@ -117,7 +117,7 @@ if [[ -z "$OLD_TAG" ]]; then
 fi
 
 if ! git -C "$REPO_ROOT" rev-parse "tags/$OLD_TAG" >/dev/null 2>&1; then
-    echo "Error: old tag '$OLD_TAG' not found. Run 'git fetch authzed --tags' first." >&2
+    echo "Error: old tag '$OLD_TAG' not found. Run 'git fetch upstream --tags' first." >&2
     exit 1
 fi
 


### PR DESCRIPTION
* Added scripts/redhat-diff.sh to isolate Red Hat-specific changes from upstream sync PRs, making code review practical by filtering out upstream noise    
* Restructured the drift tracking table in README-redhat.md to include file paths, per-file merge actions (Keep ours, Re-apply, Delete, Red Hat only), and individual rows for each workflow instead of bundled descriptions
* Added CLAUDE.md with merge conflict resolution rules to enable automated syncs via Claude Code
* Updated the git diff reference in README-redhat.md to point to the new redhat-diff.sh script       

UPDATE:
* added claude skill `sync-upstream` so that claude can be used using the `/sync-upstream` command
* added the skill and CLAUDE.md to README-redhat to ensure our specific claude configuration is tracked and properly managed during the sync process        
                         
## More on the redhat-diff.sh tool

The script compares the "Red Hat delta" (diff from upstream tag) before and after a sync. It reads the old tag from main's SYNC.md and the new tag from the merge branch's SYNC.md, then categorizes files into:  
* Red Hat changes: shown in diff output; files where Red Hat modifications were added or updated                         
* Stale files (warning): upstream deleted/renamed files that survived the merge and need removal
* Diverged files (warning): upstream files where the merge produced content that doesn't match the tag, with a fix command

```shell
  # Show diffstat summary of Red Hat changes              
  ./scripts/redhat-diff.sh --stat                         
                         
  # Full diff to stdout  
  ./scripts/redhat-diff.sh                                
                         
  # Compare a specific branch                             
  ./scripts/redhat-diff.sh --branch merge-upstream-v1.51.0                                 
                         
  # Post formatted comment on a PR (requires github CLI to work)                  
  ./scripts/redhat-diff.sh --pr <number>  
                         
  # Show cumulative Red Hat delta (all changes vs upstream)                                
  ./scripts/redhat-diff.sh --all        
```

The Red Hat changes shown in the diff can be provided on any upstream sync PR's to simplify the PR review process