### PR TITLE
updates renovate to remove updates to upstream workflows and docker images

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,17 @@
     "tekton",
     "dockerfile"
   ],
+  "ignorePaths": [
+    ".github/workflows/benchmark.yaml",
+    ".github/workflows/build-test.yaml",
+    ".github/workflows/commit-messages.yaml",
+    ".github/workflows/docs.yaml",
+    ".github/workflows/keep-a-changelog.yaml",
+    ".github/workflows/lint.yaml",
+    ".github/workflows/release-windows.yaml",
+    "Dockerfile",
+    "Dockerfile.release"
+  ],
   "packageRules": [
     {
       "matchManagers": ["dockerfile"],


### PR DESCRIPTION
Updates the renovate config to prevent Konflux from opening PR's to update any upstream workflows/docker images. These github workflows and docker images do not impact the security of our deployment and are inherited from upstream and many are disabled. Updating them outside of upstream syncs just creates more drift to track when syncing.

https://docs.renovatebot.com/configuration-options/#ignorepaths

Validation:
```
[anatale@fedora-csb spicedb]$ npx --package renovate renovate-config-validator
 INFO: Validating .github/renovate.json
 INFO: Config validated successfully
```