### PR TITLE
Renovate reconfigure & UBI 9.8

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,16 +5,10 @@
     "tekton",
     "dockerfile"
   ],
-  "ignorePaths": [
-    ".github/workflows/benchmark.yaml",
-    ".github/workflows/build-test.yaml",
-    ".github/workflows/commit-messages.yaml",
-    ".github/workflows/docs.yaml",
-    ".github/workflows/keep-a-changelog.yaml",
-    ".github/workflows/lint.yaml",
-    ".github/workflows/release-windows.yaml",
-    "Dockerfile",
-    "Dockerfile.release"
+  "includePaths": [
+    ".github/workflows/security-scanning.yml",
+    ".tekton/**",
+    "Dockerfile.fips"
   ],
   "packageRules": [
     {

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778072020 AS base
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1779809423 AS base
 ARG TARGETARCH
 USER root
 RUN microdnf install -y tar gzip make which git gcc go-toolset
@@ -23,7 +23,7 @@ RUN git checkout main
 RUN GOEXPERIMENT=strictfipsruntime,boringcrypto CGO_ENABLED=1 GOBIN=/go/bin go install -a -tags netgo -ldflags=-w
 
 # use clean base without build tools
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778072020
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1779809423
 COPY --from=health-probe-builder /go/bin/grpc-health-probe /bin/grpc_health_probe
 COPY --from=spicedb-builder /go/src/app/spicedb /usr/local/bin/spicedb
 ENV PATH="$PATH:/usr/local/bin"


### PR DESCRIPTION
- Updates renovate config to use includePaths over ignorePaths to potentially help with renovate base image bumps
-  Bumps base image for `Dockerfile.fips` to UBI 9.8