### PR TITLE
RHCLOUD-49711: Pin grpc-health-probe to tagged release

### DIFF
--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -176,6 +176,37 @@ Commit the update.
 4. Commit the cleanup
 5. Re-run `./scripts/redhat-diff.sh --stat` to confirm clean output
 
+### Step 5b: Align Dockerfile.fips grpc-health-probe pin
+
+`Dockerfile.fips` is Red Hat–only and is not updated by the merge. After cleanup,
+align its `grpc-health-probe` clone tag with the version upstream pins in
+`Dockerfile` (preferred) or `Dockerfile.release`.
+
+1. Extract the upstream probe version from the synced tree:
+   ```bash
+   # Prefer Dockerfile (ghcr image pin)
+   grep -Eo 'ghcr\.io/grpc-ecosystem/grpc-health-probe:v[0-9.]+' Dockerfile \
+     | head -1 | grep -Eo 'v[0-9.]+'
+
+   # Fallback: Dockerfile.release (GitHub release download)
+   grep -Eo 'grpc-ecosystem/grpc-health-probe/releases/download/v[0-9.]+' Dockerfile.release \
+     | head -1 | grep -Eo 'v[0-9.]+'
+   ```
+2. Read the current pin from `Dockerfile.fips`:
+   ```bash
+   grep -Eo 'git clone --branch v[0-9.]+' Dockerfile.fips | grep -Eo 'v[0-9.]+'
+   ```
+3. If the upstream version cannot be parsed, **stop and ask the user** — the
+   upstream Dockerfile format may have changed.
+4. If the versions differ, update `Dockerfile.fips` so the clone uses the
+   upstream tag, for example:
+   ```dockerfile
+   RUN git clone --branch vX.Y.Z --depth 1 https://github.com/grpc-ecosystem/grpc-health-probe.git
+   ```
+   Keep building from source with the FIPS Go toolchain. Do **not** switch to
+   `COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:...`.
+5. If `Dockerfile.fips` changed, commit the update on the sync branch.
+
 ### Step 6: Push and Create PR
 
 1. Push the branch to your fork:
@@ -196,6 +227,7 @@ Commit the update.
 Report:
 - Old tag → new tag
 - Upgrade path validation result (steps and migrations required)
+- grpc-health-probe pin in `Dockerfile.fips`: old tag → new tag (or unchanged)
 - PR link
 - Number of Red Hat changes, stale files cleaned, diverged files reset
 - Remind the user to review the PR and check CI before merging

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,16 +3,32 @@
   "enabledManagers": [
     "github-actions",
     "tekton",
-    "dockerfile"
+    "dockerfile",
+    "custom.regex"
   ],
   "includePaths": [
     ".github/workflows/security-scanning.yml",
     ".tekton/**",
     "Dockerfile.fips"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["Dockerfile.fips$"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=github-tags\\s+depName=(?<depName>\\S+)\\s*\\nRUN git clone --branch (?<currentValue>v[\\d.]+)"
+      ],
+      "datasourceTemplate": "github-tags"
+    }
+  ],
   "packageRules": [
     {
       "matchManagers": ["dockerfile"],
+      "schedule": ["* 0-7 * * 0"]
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["grpc-ecosystem/grpc-health-probe"],
       "schedule": ["* 0-7 * * 0"]
     }
   ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,32 +3,16 @@
   "enabledManagers": [
     "github-actions",
     "tekton",
-    "dockerfile",
-    "custom.regex"
+    "dockerfile"
   ],
   "includePaths": [
     ".github/workflows/security-scanning.yml",
     ".tekton/**",
     "Dockerfile.fips"
   ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["Dockerfile.fips$"],
-      "matchStrings": [
-        "#\\s*renovate:\\s*datasource=github-tags\\s+depName=(?<depName>\\S+)\\s*\\nRUN git clone --branch (?<currentValue>v[\\d.]+)"
-      ],
-      "datasourceTemplate": "github-tags"
-    }
-  ],
   "packageRules": [
     {
       "matchManagers": ["dockerfile"],
-      "schedule": ["* 0-7 * * 0"]
-    },
-    {
-      "matchManagers": ["custom.regex"],
-      "matchDepNames": ["grpc-ecosystem/grpc-health-probe"],
       "schedule": ["* 0-7 * * 0"]
     }
   ]

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
 FROM base AS health-probe-builder
 WORKDIR /go/src/app
 # renovate: datasource=github-tags depName=grpc-ecosystem/grpc-health-probe
-RUN git clone --branch v0.4.53 --depth 1 https://github.com/grpc-ecosystem/grpc-health-probe.git
+RUN git clone --branch v0.4.48 --depth 1 https://github.com/grpc-ecosystem/grpc-health-probe.git
 WORKDIR /go/src/app/grpc-health-probe
 RUN GOBIN=/go/bin go install -a -tags netgo -ldflags=-w
 

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -11,10 +11,9 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
     go mod tidy && \
     GOFLAGS="" go build -tags="memoryprotection" -ldflags=-checklinkname=0 -gcflags=all=-trimpath=/go -asmflags=all=-trimpath=/go -o spicedb ./cmd/spicedb
 
-# Builder for health probe
+# Builder for health probe — pin matches upstream Dockerfile (updated during syncs).
 FROM base AS health-probe-builder
 WORKDIR /go/src/app
-# renovate: datasource=github-tags depName=grpc-ecosystem/grpc-health-probe
 RUN git clone --branch v0.4.48 --depth 1 https://github.com/grpc-ecosystem/grpc-health-probe.git
 WORKDIR /go/src/app/grpc-health-probe
 RUN GOBIN=/go/bin go install -a -tags netgo -ldflags=-w

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -14,9 +14,9 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
 # Builder for health probe
 FROM base AS health-probe-builder
 WORKDIR /go/src/app
-RUN git clone https://github.com/authzed/grpc-health-probe.git
+# renovate: datasource=github-tags depName=grpc-ecosystem/grpc-health-probe
+RUN git clone --branch v0.4.53 --depth 1 https://github.com/grpc-ecosystem/grpc-health-probe.git
 WORKDIR /go/src/app/grpc-health-probe
-RUN git checkout main
 RUN GOBIN=/go/bin go install -a -tags netgo -ldflags=-w
 
 # Runtime stage -- set GODEBUG so the binary runs in FIPS mode.

--- a/README-redhat.md
+++ b/README-redhat.md
@@ -17,7 +17,7 @@ The table below captures all changes to our fork from upstream. Each entry inclu
 | File(s) | Change | Reason | Merge Action |
 |---------|--------|--------|-------------|
 | `.github/dependabot.yml` | Removed | Aligns with Red Hat mandates to leverage Konflux | Delete |
-| `.github/renovate.json` | Replaced with our own config | Configures Mintmaker (part of Konflux) to prevent Go pkg update PRs, move to weekly updates for Dockerfile base image updates, and track `grpc-ecosystem/grpc-health-probe` tag updates via a custom regex manager | Keep ours |
+| `.github/renovate.json` | Replaced with our own config | Configures Mintmaker (part of Konflux) to prevent Go pkg update PRs and move to weekly updates for Dockerfile base image updates | Keep ours |
 | Active workflows in `.github/workflows/` | Runner changed to `ubuntu-latest` | Authzed uses custom self-hosted runners (`depot-*`, `buildjet-*`) which we don't have access to | Re-apply |
 | `.github/workflows/build-test.yaml` | Disabled: build, steelthread, analyzer-unit, WASM, protobuf, benchmark jobs (`if: false`); disabled CockroachDB/MySQL/Spanner datastore tests; changed `Dockerfile` reference to `Dockerfile.fips`; limited Postgres versions to 16/17 | Non-critical to Red Hat builds or not applicable to our deployment targets | Re-apply |
 | `.github/workflows/benchmark.yaml` | Disabled (`if: false`) | Not critical to Red Hat builds | Re-apply |
@@ -34,7 +34,7 @@ The table below captures all changes to our fork from upstream. Each entry inclu
 | `.github/workflows/wasm.yaml` | Removed | Not applicable to our fork | Delete |
 | `.github/workflows/security-scanning.yml` | Added | Required ConsoleDot platform security workflow for CVE scanning | Red Hat only |
 | `.tekton/spicedb-pull-request.yaml`, `.tekton/spicedb-push.yaml` | Added | Konflux PR and merge build pipelines | Red Hat only |
-| `Dockerfile.fips` | Added | FIPS-compliant builds using Hummingbird base images for Konflux; grpc-health-probe built from source (pinned to a tagged release of `grpc-ecosystem/grpc-health-probe`) to enable FIPS compilation | Red Hat only |
+| `Dockerfile.fips` | Added | FIPS-compliant builds using Hummingbird base images for Konflux; grpc-health-probe built from source (pinned to a `grpc-ecosystem/grpc-health-probe` tag matching upstream `Dockerfile`, updated during syncs) to enable FIPS compilation | Red Hat only |
 | `magefiles/test.go` | Increased timeouts (unit: 20m, integration: 30m, consistency: 20m) | Tests fail with short timeouts on smaller runners | Re-apply |
 | `scripts/redhat-diff.sh` | Added | Script to isolate Red Hat-specific changes from upstream sync PRs for easier code review | Red Hat only |
 | `CLAUDE.md` | Replaced with our own | Contains Red Hat-specific merge conflict resolution rules for upstream syncs | Keep ours |

--- a/README-redhat.md
+++ b/README-redhat.md
@@ -17,7 +17,7 @@ The table below captures all changes to our fork from upstream. Each entry inclu
 | File(s) | Change | Reason | Merge Action |
 |---------|--------|--------|-------------|
 | `.github/dependabot.yml` | Removed | Aligns with Red Hat mandates to leverage Konflux | Delete |
-| `.github/renovate.json` | Replaced with our own config | Configures Mintmaker (part of Konflux) to prevent Go pkg update PRs and move to weekly updates for Dockerfile base image updates | Keep ours |
+| `.github/renovate.json` | Replaced with our own config | Configures Mintmaker (part of Konflux) to prevent Go pkg update PRs, move to weekly updates for Dockerfile base image updates, and track `grpc-ecosystem/grpc-health-probe` tag updates via a custom regex manager | Keep ours |
 | Active workflows in `.github/workflows/` | Runner changed to `ubuntu-latest` | Authzed uses custom self-hosted runners (`depot-*`, `buildjet-*`) which we don't have access to | Re-apply |
 | `.github/workflows/build-test.yaml` | Disabled: build, steelthread, analyzer-unit, WASM, protobuf, benchmark jobs (`if: false`); disabled CockroachDB/MySQL/Spanner datastore tests; changed `Dockerfile` reference to `Dockerfile.fips`; limited Postgres versions to 16/17 | Non-critical to Red Hat builds or not applicable to our deployment targets | Re-apply |
 | `.github/workflows/benchmark.yaml` | Disabled (`if: false`) | Not critical to Red Hat builds | Re-apply |
@@ -34,7 +34,7 @@ The table below captures all changes to our fork from upstream. Each entry inclu
 | `.github/workflows/wasm.yaml` | Removed | Not applicable to our fork | Delete |
 | `.github/workflows/security-scanning.yml` | Added | Required ConsoleDot platform security workflow for CVE scanning | Red Hat only |
 | `.tekton/spicedb-pull-request.yaml`, `.tekton/spicedb-push.yaml` | Added | Konflux PR and merge build pipelines | Red Hat only |
-| `Dockerfile.fips` | Added | FIPS-compliant builds using Hummingbird base images for Konflux | Red Hat only |
+| `Dockerfile.fips` | Added | FIPS-compliant builds using Hummingbird base images for Konflux; grpc-health-probe built from source (pinned to a tagged release of `grpc-ecosystem/grpc-health-probe`) to enable FIPS compilation | Red Hat only |
 | `magefiles/test.go` | Increased timeouts (unit: 20m, integration: 30m, consistency: 20m) | Tests fail with short timeouts on smaller runners | Re-apply |
 | `scripts/redhat-diff.sh` | Added | Script to isolate Red Hat-specific changes from upstream sync PRs for easier code review | Red Hat only |
 | `CLAUDE.md` | Replaced with our own | Contains Red Hat-specific merge conflict resolution rules for upstream syncs | Keep ours |


### PR DESCRIPTION
## Summary
- Pin `grpc-health-probe` in `Dockerfile.fips` to `grpc-ecosystem/grpc-health-probe` **`v0.4.48`**, matching upstream `Dockerfile` for synced SpiceDB **v1.52.0**
- Build from source with the FIPS Hummingbird Go toolchain (do not `COPY` the GHCR release binary)
- Do **not** track the probe via Renovate/Mintmaker — bump only during upstream syncs
- Extend `.claude/skills/sync-upstream` to parse the upstream probe tag from `Dockerfile` / `Dockerfile.release` and update `Dockerfile.fips`

Fixes: https://redhat.atlassian.net/browse/RHCLOUD-49711

## Why `grpc-ecosystem` instead of `authzed/grpc-health-probe`?
- Upstream SpiceDB already moved away from the Authzed fork ([authzed/spicedb@40b2715](https://github.com/authzed/spicedb/commit/40b27159b06b0cd0295c77928e2ede41159e0427)) and pins `ghcr.io/grpc-ecosystem/grpc-health-probe:<tag>`
- The Authzed repo is a fork with **no release tags**; `grpc-ecosystem` publishes tags Renovate/`github-tags` (and humans) can pin
- Its README recommends version-stamped releases and notes Kubernetes native gRPC health checking is GA (tool still useful for older K8s / advanced TLS / non-K8s)

## Verification
- Local podman build of `health-probe-builder` stage succeeds with pinned tag
- Konflux `spicedb-on-pull-request` previously built `Dockerfile.fips` successfully on this PR

## Test plan
- [x] `Dockerfile.fips` pin matches upstream `Dockerfile` (`v0.4.48`)
- [x] Renovate config no longer includes `custom.regex` for the probe
- [x] sync-upstream skill documents probe alignment step
- [ ] Image build succeeds with the pinned health-probe source